### PR TITLE
Added missing HTTP class methods on UnderOs::HTTP

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,5 @@
 source 'https://rubygems.org'
+
+gem 'motion-facon'
+
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,18 @@
 PATH
   remote: .
   specs:
-    under-os (0.0.0)
+    under-os (1.0.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    motion-facon (0.5.0.1)
     rake (10.1.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  motion-facon
   rake
   under-os!

--- a/lib/under_os/http.rb
+++ b/lib/under_os/http.rb
@@ -2,4 +2,24 @@ class UnderOs::HTTP
   def self.get(url, options={}, &block)
     Request.new(url, options.merge(method: :get), &block).send
   end
+
+  def self.post(url, options={}, &block)
+    Request.new(url, options.merge(method: :post), &block).send
+  end
+
+  def self.put(url, options={}, &block)
+    Request.new(url, options.merge(method: :put), &block).send
+  end
+
+  def self.delete(url, options={}, &block)
+    Request.new(url, options.merge(method: :delete), &block).send
+  end
+
+  def self.patch(url, options={}, &block)
+    Request.new(url, options.merge(method: :patch), &block).send
+  end
+
+  def self.head(url, options={}, &block)
+    Request.new(url, options.merge(method: :head), &block).send
+  end
 end

--- a/lib/under_os/ui/locker.rb
+++ b/lib/under_os/ui/locker.rb
@@ -1,7 +1,7 @@
 class UnderOs::UI::Locker < UnderOs::UI::View
   wraps UIView, tag: :locker
 
-  attr_reader :label, :sinner
+  attr_reader :label, :spinner
 
   def initialize(options={})
     super options

--- a/spec/lib/under_os/http_spec.rb
+++ b/spec/lib/under_os/http_spec.rb
@@ -1,0 +1,62 @@
+describe UnderOs::HTTP do
+  extend Facon::SpecHelpers
+
+  before do
+    @url = 'http://example.com/'
+    @req = mock 'request', send: :response
+  end
+
+  describe ".get" do
+    it "makes a GET request" do
+      UnderOs::HTTP::Request.should.receive(:new).
+        with(@url, foo: 'bar', method: :get).and_return @req
+
+      UnderOs::HTTP.get(@url, foo: 'bar').should == :response
+    end
+  end
+
+  describe ".post" do
+    it "makes a POST request" do
+      UnderOs::HTTP::Request.should.receive(:new).
+        with(@url, foo: 'bar', method: :post).and_return @req
+
+      UnderOs::HTTP.post(@url, foo: 'bar').should == :response
+    end
+  end
+
+  describe ".put" do
+    it "makes a PUT request" do
+      UnderOs::HTTP::Request.should.receive(:new).
+        with(@url, foo: 'bar', method: :put).and_return @req
+
+      UnderOs::HTTP.put(@url, foo: 'bar').should == :response
+    end
+  end
+
+  describe ".delete" do
+    it "makes a DELETE request" do
+      UnderOs::HTTP::Request.should.receive(:new).
+        with(@url, foo: 'bar', method: :delete).and_return @req
+
+      UnderOs::HTTP.delete(@url, foo: 'bar').should == :response
+    end
+  end
+
+  describe ".patch" do
+    it "makes a DELETE request" do
+      UnderOs::HTTP::Request.should.receive(:new).
+        with(@url, foo: 'bar', method: :patch).and_return @req
+
+      UnderOs::HTTP.patch(@url, foo: 'bar').should == :response
+    end
+  end
+
+  describe ".head" do
+    it "makes a HEAD request" do
+      UnderOs::HTTP::Request.should.receive(:new).
+        with(@url, foo: 'bar', method: :head).and_return @req
+
+      UnderOs::HTTP.head(@url, foo: 'bar').should == :response
+    end
+  end
+end


### PR DESCRIPTION
Added the **post**, **put**, **delete**, **patch** and **head** methods to `UnderOs::HTTP` and I wrote some specs using the mocking framework [motion-facon](https://github.com/svyatogor/motion-facon).

_I am guessing that `UnderOs::HTTP::Request#build_request` needs to be updated before all of the HTTP verbs can be used?_

---
##### Bonus

I also corrected `:sinner` -> `:spinner` in `UnderOs::UI::Locker`
